### PR TITLE
Fix mutable default list usage,

### DIFF
--- a/mder/__init__.py
+++ b/mder/__init__.py
@@ -35,6 +35,7 @@ please comfirm the temporary folder included the fragment video you need""")
             self.has_download_name = os.listdir(self.temp_file_path+'/TS')
         else:
             os.mkdir(self.temp_file_path+'/TS')
+            self.has_download_name = []
         with open(self.m3u8_file_path,'r') as m3u8:
             temp_url = [m3u8_lines.replace('\n','') for m3u8_lines in m3u8.readlines() if m3u8_lines.startswith('http')]
         self.total = len(temp_url)


### PR DESCRIPTION
I noticed a bug when running the downloader twice: self.has_download_name uses a default value of [], which is mutable and shared across classes. By modifying self.has_download_name without creating a separate array for it, the added values are shared across several runs. Subsequent calls to mder.m3u8_downloader([...]).start() will fail, as self.has_download_name will always be longer than self.names.

The error can be easily reproduced by calling mder.m3u8_downloader([...]).start() twice on different temp_file_paths.